### PR TITLE
feat: Chroma export usability

### DIFF
--- a/chroma_dp/chroma/chroma_export.py
+++ b/chroma_dp/chroma/chroma_export.py
@@ -71,8 +71,6 @@ def read_large_data_in_chunks(
 def chroma_export(
     uri: str,
     collection: Optional[str] = None,
-    export_file: Optional[str] = None,
-    append: Optional[bool] = False,
     limit: Optional[int] = -1,
     offset: Optional[int] = 0,
     batch_size: Optional[int] = 100,
@@ -100,9 +98,6 @@ def chroma_export(
     _where_document = None
     if where_document:
         _where_document = validate_where_document(json.loads(where_document))
-    if export_file and not append:
-        with open(export_file, "w") as f:
-            f.write("")
     for offset in range(_start, total_results_to_fetch, _batch_size):
         _results = _get_result_to_chroma_doc_list(
             read_large_data_in_chunks(
@@ -171,11 +166,12 @@ def chroma_export_cli(
         help="Export format. Default is `record`. Supported formats: `record` and `jsonl`. ",
     ),
 ) -> None:
+    if export_file and not append:
+        with open(export_file, "w") as f:
+            f.write("")
     _final_results = chroma_export(
         uri=uri,
         collection=collection,
-        export_file=export_file,
-        append=append,
         limit=limit,
         offset=offset,
         batch_size=batch_size,

--- a/chroma_dp/main.py
+++ b/chroma_dp/main.py
@@ -1,6 +1,6 @@
 import typer
 from dotenv import load_dotenv
-from chroma_dp.chroma.chroma_export import chroma_export
+from chroma_dp.chroma.chroma_export import chroma_export_cli
 from chroma_dp.chroma.chroma_import import chroma_import
 from chroma_dp.processor.chunk import chunk_process
 from chroma_dp.processor.embed import filter_embed
@@ -72,7 +72,7 @@ app.command(
     name="export",
     help="Export data from ChromaDB.",
     no_args_is_help=True,
-)(chroma_export)
+)(chroma_export_cli)
 
 app.command(
     name="import",
@@ -80,7 +80,7 @@ app.command(
     no_args_is_help=True,
 )(chroma_import)
 
-## Dataset commands
+# Dataset commands
 
 
 app.command(
@@ -95,7 +95,7 @@ app.command(
     no_args_is_help=True,
 )(hf_export)
 
-## Metadata processor
+# Metadata processor
 
 app.command(
     name="meta",
@@ -103,7 +103,7 @@ app.command(
     no_args_is_help=True,
 )(meta_process)
 
-## ID processor
+# ID processor
 
 
 app.command(


### PR DESCRIPTION
Made chroma export command more usable by splitting the CLI parts into a separate function than the core export function that only interacts with Chroma. Writing to stdin or file is now done within the CLI part

Refs: #129
